### PR TITLE
Add logstash format by config

### DIFF
--- a/log.go
+++ b/log.go
@@ -19,8 +19,10 @@ var (
 	// ErrEmptyValue is the error returned when there is no config under the namespace
 	ErrWrongConfig = fmt.Errorf("getting the extra config for the krakend-gologging module")
 	// DefaultPattern is the pattern to use for rendering the logs
+	logstashPattern          = `{"@timestamp":"%{time:200-01-02T15:04:05.000+00:00}", "@version": 1, "level": "%{level}", "message": "%{message}", "module": "%{module}"}`
 	DefaultPattern           = ` %{time:2006/01/02 - 15:04:05.000} %{color}▶ %{level:.6s}%{color:reset} %{message}`
-	defaultFormatterSelector = func(io.Writer) string { return DefaultPattern }
+	ActivePattern            = DefaultPattern
+	defaultFormatterSelector = func(io.Writer) string { return ActivePattern }
 )
 
 // SetFormatterSelector sets the ddefaultFormatterSelector function
@@ -49,6 +51,11 @@ func NewLogger(cfg config.ExtraConfig, ws ...io.Writer) (logging.Logger, error) 
 			return nil, err
 		}
 		ws = append(ws, w)
+	}
+
+	if logConfig.Format == "logstash" {
+		ActivePattern = logstashPattern
+		logConfig.Prefix = ""
 	}
 
 	backends := []gologging.Backend{}
@@ -92,6 +99,9 @@ func ConfigGetter(e config.ExtraConfig) interface{} {
 	if v, ok := tmp["prefix"]; ok {
 		cfg.Prefix = v.(string)
 	}
+	if v, ok := tmp["format"]; ok {
+		cfg.Format = v.(string)
+	}
 	return cfg
 }
 
@@ -101,6 +111,7 @@ type Config struct {
 	StdOut bool
 	Syslog bool
 	Prefix string
+	Format string
 }
 
 // Logger is a wrapper over a github.com/op/go-logging logger

--- a/log_test.go
+++ b/log_test.go
@@ -2,8 +2,10 @@ package gologging
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"regexp"
+	"strings"
 	"testing"
 
 	gologging "github.com/op/go-logging"
@@ -41,8 +43,29 @@ func TestNewLogger(t *testing.T) {
 	}
 }
 
+func TestNewLogger_logstashFormat(t *testing.T) {
+	buff := bytes.NewBuffer(make([]byte, 1024))
+	SetFormatterSelector(func(w io.Writer) string {
+		return ActivePattern
+	})
+	logger, err := NewLogger(newExtraConfig("DEBUG", "logstash"), TestFormatWriter{buff})
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	logger.Critical(criticalMsg)
+
+	outputMsg := strings.Replace(buff.String(), "\x00", "", -1)
+
+	if !isJson(outputMsg) || !strings.HasPrefix(outputMsg, "{\"@timestamp\":") {
+		t.Error("The output doesn't contain a logstash formatted log line")
+	}
+}
+
 func TestNewLogger_unknownLevel(t *testing.T) {
-	_, err := NewLogger(newExtraConfig("UNKNOWN"), bytes.NewBuffer(make([]byte, 1024)))
+	_, err := NewLogger(newExtraConfig("UNKNOWN", "default"), bytes.NewBuffer(make([]byte, 1024)))
 	if err == nil {
 		t.Error("The factory didn't return the expected error")
 		return
@@ -52,13 +75,14 @@ func TestNewLogger_unknownLevel(t *testing.T) {
 	}
 }
 
-func newExtraConfig(level string) map[string]interface{} {
+func newExtraConfig(level string, format string) map[string]interface{} {
 	return map[string]interface{}{
 		Namespace: map[string]interface{}{
 			"level":  level,
 			"prefix": "pref",
 			"syslog": false,
 			"stdout": true,
+			"format": format,
 		},
 	}
 }
@@ -77,7 +101,7 @@ func logSomeStuff(level string) (string, error) {
 			return DefaultPattern
 		}
 	})
-	logger, err := NewLogger(newExtraConfig(level), TestFormatWriter{buff})
+	logger, err := NewLogger(newExtraConfig(level, "default"), TestFormatWriter{buff})
 	if err != nil {
 		return "", err
 	}
@@ -89,4 +113,10 @@ func logSomeStuff(level string) (string, error) {
 	logger.Critical(criticalMsg)
 
 	return buff.String(), nil
+}
+
+func isJson(possibleJson string) bool {
+	var js map[string]interface{}
+
+	return json.Unmarshal([]byte(possibleJson), &js) == nil
 }


### PR DESCRIPTION
This will enable having a new field in the extra config
```
"github_com/devopsfaith/krakend-gologging": {
  "level": "WARNING",
  "syslog": false,
  "stdout": true,
  "format": "logstash" ⬅️
}
```

That will log with a logstash-compatible format.

This is not including any breaking change