### PR TITLE
allow build on windows, disabling syslog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/devopsfaith/krakend-gologging
+
+go 1.12

--- a/log_windows.go
+++ b/log_windows.go
@@ -1,4 +1,4 @@
-// +build !windows, !plan9
+// +build windows, plan9
 
 //Package gologging provides a logger implementation based on the github.com/op/go-logging pkg
 package gologging
@@ -43,9 +43,6 @@ func NewLogger(cfg config.ExtraConfig, ws ...io.Writer) (logging.Logger, error) 
 
 	if logConfig.StdOut {
 		ws = append(ws, os.Stdout)
-	}
-
-	if logConfig.Syslog {
 	}
 
 	if logConfig.Format == "logstash" {


### PR DESCRIPTION
try to build krakend for windows, but building failed.
I just recognise, as far as i tested it, the only reason why krakend-ce build failed for windows is, that the logging is using syslog, which is not availble for windows and plan9.
I would like to have a krakend as a windows binary.

I just dig a little deeper in this issue and implemented a little work around, 2 src files with different build tags, one for windows without syslog and one for the rest.